### PR TITLE
fix: flask 2.X compatibility

### DIFF
--- a/src/flask_sqlalchemy_lite/_extension.py
+++ b/src/flask_sqlalchemy_lite/_extension.py
@@ -9,7 +9,12 @@ import sqlalchemy.ext.asyncio as sa_async
 import sqlalchemy.orm as orm
 from flask import current_app
 from flask import g
-from flask.sansio.app import App
+
+try:
+    # For Flask 3.X and later, use the sansio app
+    from flask.sansio.app import App
+except ImportError:
+    from flask.app import Flask as App
 
 from ._cli import add_models_to_shell
 from ._make import _make_engines

--- a/src/flask_sqlalchemy_lite/_make.py
+++ b/src/flask_sqlalchemy_lite/_make.py
@@ -4,7 +4,12 @@ import os
 import typing as t
 
 import sqlalchemy as sa
-from flask.sansio.app import App
+
+try:
+    # For Flask 3.X and later, use the sansio app
+    from flask.sansio.app import App
+except ImportError:
+    from flask.app import Flask as App
 from sqlalchemy import orm as orm
 from sqlalchemy.ext import asyncio as sa_async
 


### PR DESCRIPTION
Currently there are no package constraints defined for Flask's version, yet flask-sqlalchemy-lite fails with:

```
  File "./venv/lib/python3.10/site-packages/flask_sqlalchemy_lite/_extension.py", line 12, in <module>
    from flask.sansio.app import App
ModuleNotFoundError: No module named 'flask.sansio'
```

Solution:
Since `App` is only used for type checking, this PR introduces a try/except import to fall back to Flask from flask.app in environments where flask.sansio.app is unavailable. This ensures retro compatibility without requiring users to upgrade Flask unnecessarily.

Impact:
This is a minimal and safe change that restores compatibility with Flask versions <3.0 while preserving type checking behavior for 3.x+.
