### PR TITLE
add abort methods

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 Unreleased
 
 -   Drop support for Python 3.9.
+-   Add `get_or_abort` and `one_or_abort` methods, which get a single row or
+    otherwise tell Flask to abort with a 404 error.
 
 ## Version 0.1.0
 

--- a/docs/start.md
+++ b/docs/start.md
@@ -170,6 +170,37 @@ def user_create():
     return app.redirect(app.url_for("user_list"))
 ```
 
+### Get or Abort
+
+A common pattern is to fetch a single row by some unique key in order to show
+a detail page for it. If the row doesn't exist, you want to return a 404 error.
+Some helper methods are provided to handle this.
+
+Use {meth}`.SQLAlchemy.get_or_abort` to get a model instance by primary key. If
+the key doesn't exist, it calls {func}`flask.abort` to raise a 404 error.
+
+```python
+@app.get("/invoice/<int:id>")
+def invoice_detail(id: int):
+    obj: Invoice = db.get_or_abort(Invoice, id)
+    ...
+```
+
+You might want to use some "natural key" rather than having the primary key in
+the URL. {meth}`.SQLAlchemy.one_or_abort` handles using an arbitrary select
+statement instead of the primary key. If there is not exactly one result, abort
+is called.
+
+```python
+@app.get("/invoice/<company>/<date>")
+def invoice_detail(company: str, date: str):
+    query = select(Invoice).where(Invoice.company == company, Invoice.date == date)
+    obj: Invoice = db.one_or_abort(query)
+    ...
+```
+
+The methods take more arguments to customize the query execution and abort
+arguments, see their docs for more.
 
 ### Application Context
 

--- a/tests/test_abort.py
+++ b/tests/test_abort.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import pytest
+import sqlalchemy as sa
+from flask import Flask
+from sqlalchemy import orm
+from werkzeug.exceptions import NotFound
+
+from flask_sqlalchemy_lite import SQLAlchemy
+
+
+class Base(orm.DeclarativeBase):
+    pass
+
+
+class Todo(Base):
+    __tablename__ = "todo"
+    id: orm.Mapped[int] = orm.mapped_column(primary_key=True)
+    name: orm.Mapped[str]
+
+
+@pytest.fixture(autouse=True)
+def _init_db(app: Flask, db: SQLAlchemy) -> None:
+    with app.app_context():
+        Base.metadata.create_all(db.engine)
+        db.session.add(Todo(name="a"))
+        db.session.add(Todo(name="b"))
+        db.session.add(Todo(name="a"))
+        db.session.commit()
+
+
+@pytest.mark.usefixtures("app_ctx")
+def test_get(db: SQLAlchemy) -> None:
+    assert db.get_or_abort(Todo, 1).name == "a"
+
+
+@pytest.mark.usefixtures("app_ctx")
+def test_get_abort(db: SQLAlchemy) -> None:
+    with pytest.raises(NotFound):
+        db.get_or_abort(Todo, 4)
+
+
+@pytest.mark.usefixtures("app_ctx")
+def test_get_session(db: SQLAlchemy) -> None:
+    assert db.get_or_abort(Todo, 2, session=db.get_session("x")).name == "b"
+
+
+@pytest.mark.usefixtures("app_ctx")
+def test_one(db: SQLAlchemy) -> None:
+    assert db.one_or_abort(sa.select(Todo).where(Todo.name == "b")).name == "b"
+
+
+@pytest.mark.usefixtures("app_ctx")
+def test_one_abort_none(db: SQLAlchemy) -> None:
+    with pytest.raises(NotFound):
+        db.one_or_abort(sa.select(Todo).where(Todo.name == "c"))
+
+
+@pytest.mark.usefixtures("app_ctx")
+def test_one_abort_many(db: SQLAlchemy) -> None:
+    query = sa.select(Todo).where(Todo.name == "a")
+
+    with pytest.raises(NotFound):
+        db.one_or_abort(query)
+
+
+@pytest.mark.usefixtures("app_ctx")
+def test_one_tuple(db: SQLAlchemy) -> None:
+    assert db.one_or_abort(
+        sa.select(Todo.id, Todo.name).where(Todo.name == "b"), scalar=False
+    ) == (2, "b")
+
+
+@pytest.mark.usefixtures("app_ctx")
+def test_one_session(db: SQLAlchemy) -> None:
+    assert (
+        db.one_or_abort(
+            sa.select(Todo).where(Todo.name == "b"), session=db.get_session("x")
+        ).name
+        == "b"
+    )


### PR DESCRIPTION
Add `get_or_abort` and `one_or_abort` methods (and async variants), which will return a single row or call `flask.abort(404)`. These are similar to `get_or_404` etc from Flask-SQLAlchemy. They take arguments to customize the query execution as well as the abort call.

I decided not to port `first_or_404` because these methods seem intended for detail pages, where `first` would not catch that the result may not be unique. `one_or_abort` covers that case. 

`get` will always return a model instance, but `one` works on any select statement, which returns a tuple result. I added a `scalar` argument to control whether to return a single item or the tuple result. It defaults to true since the common use case will be to query a model rather than a tuple of columns. It's possible to introspect the select statement to determine whether a single model is being queried, but I felt explicitly passing `scalar=False` was preferable.

For the first release of Flask-SQLAlchemy-Lite, I wanted to keep it as simple as possible, waiting to see what may be needed from Flask-SQLAlchemy. These helper methods handle a really common pattern in web applications, and go beyond just tweaking SQLAlchemy to actually integrate with Flask. So I felt it was appropriate to have these in this "light" extension.
