### PR TITLE
add test isolation manager

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@ Unreleased
 -   Drop support for Python 3.9.
 -   Add `get_or_abort` and `one_or_abort` methods, which get a single row or
     otherwise tell Flask to abort with a 404 error.
+-   Add `test_isolation` context manager, which isolates changes to the database
+    so that tests don't affect each other.
 
 ## Version 0.1.0
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,12 +2,17 @@ from __future__ import annotations
 
 import collections.abc as cabc
 import os
+import sys
 import typing as t
 from pathlib import Path
 
 import pytest
+import sqlalchemy as sa
 from flask import Flask
 from flask.ctx import AppContext
+from sqlalchemy import event
+from sqlalchemy.engine.interfaces import DBAPIConnection
+from sqlalchemy.pool import ConnectionPoolEntry
 
 from flask_sqlalchemy_lite import SQLAlchemy
 
@@ -44,4 +49,32 @@ def app_ctx(app: Flask) -> t.Iterator[AppContext]:
 
 @pytest.fixture
 def db(app: Flask) -> SQLAlchemy:
-    return SQLAlchemy(app)
+    engine_options: dict[str, t.Any] = {}
+
+    if sys.version_info >= (3, 12):
+        # Fix sqlite driver's handling of transactions.
+        # https://docs.sqlalchemy.org/en/20/dialects/sqlite.html#sqlite-transactions
+        engine_options["connect_args"] = {"autocommit": False}
+
+    return SQLAlchemy(app, engine_options=engine_options)
+
+
+if sys.version_info < (3, 12):
+    # Fix sqlite3 driver's handling of transactions.
+    # https://docs.sqlalchemy.org/en/20/dialects/sqlite.html#sqlite-transactions
+
+    def _sqlite_connect(
+        dbapi_connection: DBAPIConnection, connection_record: ConnectionPoolEntry
+    ) -> None:
+        dbapi_connection.isolation_level = None
+
+    def _sqlite_begin(conn: sa.Connection) -> None:
+        conn.exec_driver_sql("BEGIN")
+
+    @pytest.fixture(scope="session", autouse=True)
+    def _sqlite_isolation() -> cabc.Iterator[None]:
+        event.listen(sa.Engine, "connect", _sqlite_connect)
+        event.listen(sa.Engine, "begin", _sqlite_begin)
+        yield
+        event.remove(sa.Engine, "begin", _sqlite_begin)
+        event.remove(sa.Engine, "connect", _sqlite_connect)

--- a/tests/test_isolation.py
+++ b/tests/test_isolation.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+from flask import Flask
+from sqlalchemy import orm
+
+from flask_sqlalchemy_lite import SQLAlchemy
+
+
+class Base(orm.DeclarativeBase):
+    pass
+
+
+class Todo(Base):
+    __tablename__ = "todo"
+    id: orm.Mapped[int] = orm.mapped_column(primary_key=True)
+
+
+def test_isolation(app: Flask, db: SQLAlchemy) -> None:
+    # Database setup, this item will be present at the start of each isolated block.
+    with app.app_context():
+        Base.metadata.create_all(db.engine)
+        db.session.add(Todo())
+        db.session.commit()
+
+    # Sees the setup item, adds a new item.
+    with app.app_context(), db.test_isolation():
+        db.session.add(Todo())
+        db.session.commit()
+        assert db.session.scalar(sa.select(sa.func.count(Todo.id))) == 2
+
+    # Does not see the previous added item, deletes the setup item.
+    with app.app_context(), db.test_isolation():
+        assert db.session.scalar(sa.select(sa.func.count(Todo.id))) == 1
+        db.session.delete(db.session.get_one(Todo, 1))
+        db.session.commit()
+        assert db.session.scalar(sa.select(sa.func.count(Todo.id))) == 0
+
+    # Deleted setup item has returned.
+    with app.app_context():
+        assert db.session.scalar(sa.select(sa.func.count(Todo.id))) == 1


### PR DESCRIPTION
Add a `test_isolation` context manager method (and async variant). This turns the code previously described in the "Avoid Writing Data" section of the testing docs into a context manager. The code was pretty complex, this hides that in a simple `with` block for users. Now the code is much shorter:

```python
@pytest.fixture
def app(monkeypatch):
    app = create_app({
        "SQLALCHEMY_ENGINES": {"default": "postgresql:///project-test"}
    })

    with db.test_isolation():
        yield app
```

This also works with unittest:

```python
class TestDatabase(unittest.TestCase):
    def setUp(self):
        self.enterContext(db.test_isolation())
```

Any changes to the database within the `with` block will be rolled back when it exits.

Our tests use SQLite, and we call out in the docs that you don't need this isolation code and can just blow away the in-memory database for each test in that case. However, it does work with SQLite, but SQLite's transaction handling needs to be fixed: https://docs.sqlalchemy.org/en/20/dialects/sqlite.html#sqlite-transactions. So our tests serve as a demonstration for how to use this with SQLite.