### PR TITLE
fix sessionmakers use wrong binds with multiple apps

### DIFF
--- a/src/flask_sqlalchemy_lite/_make.py
+++ b/src/flask_sqlalchemy_lite/_make.py
@@ -163,14 +163,18 @@ def _make_sessionmaker(
         options["bind"] = engines["default"]
 
     if "binds" in options:
-        for base, bind in options["binds"].items():
+        binds = options["binds"]
+        options["binds"] = binds.copy()
+        for base, bind in binds.items():
             if isinstance(bind, str):
                 if bind not in engines:
+                    if is_async:
+                        del options["binds"][base]
+                        continue
                     raise RuntimeError(
                         f"'{config_key}[\"{bind}\"]' is not defined, but is"
                         " used in 'session_options[\"binds\"]'."
                     )
-
                 options["binds"][base] = engines[bind]
 
     return make(**options)


### PR DESCRIPTION
Fixes #41 

`options["binds"]` uses a copy of `SQLAlchemy._session_options["binds"]` so that the original dict isn't modified. 

It was also necessary to add special handling for cases where `SQLALCHEMY_ASYNC_ENGINES` isn't configured, although I'm not convinced that this approach is correct. In v0.2.1, the end result on the async factory would be `db.async_sessionmaker.kw["binds"] == db.sessionmaker.kw["binds"]`. With these changes, `db.async_sessionmaker.kw["binds"] == {}` (which is essentially equivalent to `None` when finally passed to `Session.__init__`).
